### PR TITLE
Fixed caching issue for GameState objects

### DIFF
--- a/_main_project/_commands/management/commands/load_active_game_states.py
+++ b/_main_project/_commands/management/commands/load_active_game_states.py
@@ -1,3 +1,4 @@
+import pickle # Used to serialize and deserialize the `GameState` objects. This is IMPORTANT! Otherwise, the `GameState` objects will not be restored correctly from the cache.
 from django.core.management.base import BaseCommand
 from a_game.models import GameSession
 from a_game.game_logic import GameState
@@ -28,6 +29,6 @@ def load_active_game_states():
 		game_state.score2 = session.score2
 		game_state.score3 = session.score3
 		game_state.score4 = session.score4
-		cache.set(session.game_id, game_state)
+		cache.set(session.game_id, pickle.dumps(game_state))
 		# print(f'Active game state loaded into cache: {session.game_id}')
 	print(f'Active game states loaded into cache: {cache.keys("*")}')

--- a/_main_project/a_game/consumers.py
+++ b/_main_project/a_game/consumers.py
@@ -54,7 +54,8 @@ class PongConsumer(AsyncWebsocketConsumer):
 
 		# Remove the player from the ready players list
 		if self.game_id in ready_players:
-			ready_players[self.game_id].remove(self.channel_name)
+			if self.channel_name in ready_players[self.game_id]:
+				ready_players[self.game_id].remove(self.channel_name)
 			if not ready_players[self.game_id]:
 				del ready_players[self.game_id]
 

--- a/_main_project/a_game/game_logic.py
+++ b/_main_project/a_game/game_logic.py
@@ -1,6 +1,6 @@
 # This file contains the game logic for the Pong game. 
 # The GameState class object is initialized once the game session is created in the views.py file.
-# The GameState objects are stored in the game_states dictionary, with the game_id as the key.
+# The GameState objects are stored in the Redis cache with the game_id as the key.
 # There can be only one GameState object per game_id / game session.
 
 import random
@@ -199,6 +199,9 @@ class GameState:
 		# self.ball_velocity_y = (self.ball_velocity_y / speed) * BALL_VELOCITY_Y
 
 	def move_paddle(self, paddle, direction):
+		# DEBUG # 
+		# print(f'Moving paddle {paddle}')
+
 		if paddle == 1:
 			self.paddle1 += direction * PADDLE_SPEED
 		elif paddle == 2:
@@ -215,7 +218,6 @@ class GameState:
 		self.paddle4 = max(0, min(self.paddle4, CANVAS_WIDTH - PADDLE_WIDTH))
 	
 	# To get the winner of the game: 
-	# `getattr(game_states[game_id], "winner", None)` - this will return the winner of the game if the game is over, otherwise it will return None
 	def check_winner(self):
 		if self.score1 >= WINNING_SCORE:
 			self.game_over = True

--- a/_main_project/static/css/game.css
+++ b/_main_project/static/css/game.css
@@ -1,1 +1,14 @@
 /*////////////////////  PONG GAME //////////////////////////////*/
+
+/* Modal that contains the Game */
+.modal-game {
+	display: none;
+	justify-content: center;
+	position: fixed;
+	z-index: 1;
+	left: 0;
+	top: var(--nav-height);
+	width: 100%;
+	height: calc(100vh - calc(var(--nav-height) + var(--footer-height)));
+	background-color: var(--background-color);
+  }

--- a/_main_project/static/js/game/GameLogic.js
+++ b/_main_project/static/js/game/GameLogic.js
@@ -45,6 +45,7 @@ export async function initializeGame(socket, role, game_id) {
 	// updateGameState(gameState);
 
 	function updateGameState(gameState) {
+		// console.log('..updateGameState, gameState: ', gameState);
 		mode = gameState.game_mode;
 		numPlayers = gameState.num_players;
 		paddle1 = gameState.paddle1;
@@ -55,13 +56,12 @@ export async function initializeGame(socket, role, game_id) {
 		score2 = gameState.score2;
 		score3 = gameState.score3;
 		score4 = gameState.score4;
-		// console.log('..score1: ', score1, ' score2: ', score2);
 	}
 
     socket.onmessage = function(event) {
 		// console.log('WebSocket message received: ', event.data.type);
 		const data = JSON.parse(event.data);
-		// console.log('..onmessage, data.type: ', data.type);
+		// console.log('..WebSocket ..paddle1: ', data.paddle1, ' paddle2: ', data.paddle2);
 		if (data.type === 'initial_state') {
 			const gameState = data.state;
 			updateGameState(gameState);
@@ -76,7 +76,8 @@ export async function initializeGame(socket, role, game_id) {
 			paddle2 = data.paddle2;
 			paddle3 = data.paddle3;
 			paddle4 = data.paddle4;
-			// winner = data.winner;
+
+			// console.log('..update_state, paddle1: ', paddle1, ' paddle2: ', paddle2);
 		} else if (data.type === 'game_over') {
 			winner = data.winner;
 			// alert(`Game Over! ${winner} wins!`);
@@ -152,11 +153,11 @@ export async function initializeGame(socket, role, game_id) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         drawPaddle1();
         drawPaddle2();
-		if (numPlayers === 3) {
+		if (numPlayers >= 3) {
 			drawPaddle3();
-		} else if (numPlayers === 4) {
-			drawPaddle3();
-			drawPaddle4();
+			if (numPlayers === 4) {
+				drawPaddle4();
+			}
 		}
         drawBall();
 		drawScore();


### PR DESCRIPTION
This PR fixes:

- Added back the `.modal-game` class into the `game.css` file to fix the GameBoard view on the front.
- Error in the `end_game_session` endpoint.
- Important fix with the caching behavior of the active GameState objects. The issue was the serialization/deserialization of the GameState objects into/from the cache. 

Since the paddle move is updated via API and all other updates via WebSockets, there was an issue with the paddle not moving at all.
Fixed.